### PR TITLE
[fix] `split`,`rsplit`,`partition` and `rpartition` method

### DIFF
--- a/Sources/SwiftyPyString/SwiftyPyString.swift
+++ b/Sources/SwiftyPyString/SwiftyPyString.swift
@@ -431,7 +431,11 @@ extension String {
         return (tmp[0], sep, tmp[1])
     }
     func _rsplit(_ sep: String, maxsplit: Int) -> [String] {
+        if self.isEmpty {
+            return [self]
+        }
         if sep.isEmpty {
+            // error
             return self._rsplit(maxsplit: maxsplit)
         }
         var result: [String] = []
@@ -510,7 +514,11 @@ extension String {
         return self[nil, i == -1 ? nil : i + 1]
     }
     func _split(_ sep: String, maxsplit: Int) -> [String] {
+        if self.isEmpty {
+            return [self]
+        }
         if sep.isEmpty {
+            // error
             return self._split(maxsplit: maxsplit)
         }
         var maxsplit = maxsplit

--- a/Tests/SwiftyPyStringTests/EmptyStringTest.swift
+++ b/Tests/SwiftyPyStringTests/EmptyStringTest.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import SwiftyPyString
+
+final class EmptyStringTests: XCTestCase {
+
+    func testCapitalize() throws {
+        XCTAssertEqual("".capitalize(), "")
+    }
+    func testCasefold() throws {
+        XCTAssertEqual("".casefold(), "")
+    }
+    func testCenter() throws {
+        XCTAssertEqual("".center(10), "          ")
+    }
+    func testCount() throws {
+        XCTAssertEqual("".count("a"), 0)
+        XCTAssertEqual("".count(""), 1)
+        XCTAssertEqual("文字列".count(""), 4)
+    }
+    func testEndswith() throws {
+        let empty: String = ""
+
+        XCTAssertFalse(empty.endswith("world"))
+        XCTAssertTrue("world".endswith(""))
+        XCTAssertTrue(empty.endswith(""))
+    }
+    func testExpandtabs() throws {
+        XCTAssertEqual("".expandtabs(), "")
+        XCTAssertEqual("".expandtabs(0), "")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+        #if os(macOS)
+            for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+                return bundle.bundleURL.deletingLastPathComponent()
+            }
+            fatalError("couldn't find the products directory")
+        #else
+            return Bundle.main.bundleURL
+        #endif
+    }
+}

--- a/Tests/SwiftyPyStringTests/EmptyStringTest.swift
+++ b/Tests/SwiftyPyStringTests/EmptyStringTest.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class EmptyStringTests: XCTestCase {
 
+    let empty = ""
+
     func testCapitalize() throws {
         XCTAssertEqual("".capitalize(), "")
     }
@@ -18,8 +20,6 @@ final class EmptyStringTests: XCTestCase {
         XCTAssertEqual("文字列".count(""), 4)
     }
     func testEndswith() throws {
-        let empty: String = ""
-
         XCTAssertFalse(empty.endswith("world"))
         XCTAssertTrue("world".endswith(""))
         XCTAssertTrue(empty.endswith(""))
@@ -27,6 +27,116 @@ final class EmptyStringTests: XCTestCase {
     func testExpandtabs() throws {
         XCTAssertEqual("".expandtabs(), "")
         XCTAssertEqual("".expandtabs(0), "")
+    }
+    func testFind() throws {
+        let str = "0123456789"
+        XCTAssertEqual(empty.find(""), 0)
+        XCTAssertEqual(empty.find("5"), -1)
+        XCTAssertEqual(str.find(empty), 0)
+    }
+    func testIsAlnum() throws {
+        XCTAssertFalse("".isalnum())
+    }
+    func testIsAlpha() throws {
+        XCTAssertFalse("".isalpha())
+    }
+    func testIsAscii() throws {
+        XCTAssertTrue("".isascii())
+    }
+    func testIsDecimal() throws {
+        XCTAssertFalse("".isdecimal())
+    }
+    func testIsDigit() throws {
+        XCTAssertFalse("".isdigit())
+    }
+    func testIsLower() throws {
+        XCTAssertFalse("".islower())
+    }
+    func testIsPrintable() throws {
+        XCTAssertTrue("".isprintable())
+    }
+    func testIsSpace() throws {
+        XCTAssertFalse("".isspace())
+    }
+    func testIsNumeric() throws {
+        XCTAssertFalse("".isnumeric())
+    }
+    func testIsTitle() throws {
+        XCTAssertFalse("".istitle())
+    }
+    func testIsUpper() throws {
+        XCTAssertFalse("".isupper())
+    }
+    func testJoin() throws {
+        let arry: [String] = []
+        XCTAssertEqual("".join(arry), "")
+    }
+    func testLjust() throws {
+        XCTAssertEqual(empty.ljust(1), " ")
+        XCTAssertEqual(empty.ljust(5, fillchar: "z"), "zzzzz")
+    }
+    func testLower() throws {
+        XCTAssertEqual("".lower(), "")
+    }
+    func testLstrip() throws {
+        XCTAssertEqual("".lstrip(), "")
+    }
+    func testMaketrans() throws {
+        XCTAssertEqual(String.maketrans("", y: ""), [:])
+    }
+    func testPartition() throws {
+        XCTAssert("".partition(",") == ("", "", ""))
+    }
+    func testReplaceEmpty() throws {
+        XCTAssertEqual("".replace("", new: "p"), "p")
+        XCTAssertEqual("".replace("", new: "p", count: 0), "")
+        XCTAssertEqual("".replace("", new: "p", count: 1), "")
+    }
+    func testRfind() throws {
+        XCTAssertEqual(empty.rfind(""), empty.count)
+        XCTAssertEqual(empty.rfind("x"), -1)
+    }
+    func testRjust() throws {
+        XCTAssertEqual(empty.rjust(1), " ")
+        XCTAssertEqual(empty.rjust(5, fillchar: "z"), "zzzzz")
+    }
+    func testRpartition() throws {
+        XCTAssert("".rpartition(",") == ("", "", ""))
+    }
+    func testRsplit() throws {
+        XCTAssertEqual("".rsplit(","), [""])
+        XCTAssertEqual("".rsplit(), [])
+    }
+    func testRstrip() throws {
+        XCTAssertEqual("".rstrip(), "")
+    }
+    func testSplit() throws {
+        XCTAssertEqual("".split(","), [""])
+        XCTAssertEqual("".split(), [])
+    }
+    func testSplitlines() throws {
+        XCTAssertEqual("".splitlines(), [])
+        XCTAssertEqual("".splitlines(true), [])
+    }
+    func testStartswith() throws {
+        XCTAssertTrue("".startswith(""))
+        XCTAssertTrue("world".startswith(""))
+    }
+    func testStrip() throws {
+        XCTAssertEqual("".strip(), "")
+    }
+    func testSwapcase() throws {
+        XCTAssertEqual("".swapcase(), "")
+    }
+    func testTitle() throws {
+        XCTAssertEqual("".title(), "")
+    }
+
+    func testUpper() throws {
+        XCTAssertEqual("".upper(), "")
+    }
+    func testZfill() throws {
+        XCTAssertEqual(empty.zfill(2), "00")
     }
 
     /// Returns path to the built products directory.

--- a/Tests/SwiftyPyStringTests/SliceTests.swift
+++ b/Tests/SwiftyPyStringTests/SliceTests.swift
@@ -69,14 +69,14 @@ final class SliceTests: XCTestCase {
     /// Returns path to the built products directory.
     var productsDirectory: URL {
         #if os(macOS)
-        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return bundle.bundleURL.deletingLastPathComponent()
-        }
-        fatalError("couldn't find the products directory")
+            for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+                return bundle.bundleURL.deletingLastPathComponent()
+            }
+            fatalError("couldn't find the products directory")
         #else
-        return Bundle.main.bundleURL
+            return Bundle.main.bundleURL
         #endif
     }
 }
 
-extension Array: Sliceable {}
+extension Array: Sliceable { }

--- a/Tests/SwiftyPyStringTests/SliceTests.swift
+++ b/Tests/SwiftyPyStringTests/SliceTests.swift
@@ -53,10 +53,18 @@ final class SliceTests: XCTestCase {
         XCTAssertEqual(str[nil, nil, -1], "9876543210")
         XCTAssertEqual(str[nil, nil, -2], "97531")
     }
+    func testSliceEmpty() throws {
+        let empty = ""
+        XCTAssertEqual(empty[0, 0], "")
+        XCTAssertEqual(empty[0, -1], "")
+        XCTAssertEqual(empty[0, 1], "")
+        XCTAssertEqual(empty[-1, 0], "")
+        XCTAssertEqual(empty[1, 0], "")
+    }
     func testSliceable() throws {
         let list = [1, 2, 3]
         XCTAssertEqual(list[nil, nil, -1], [3, 2, 1])
-        XCTAssertEqual(list[0],1)
+        XCTAssertEqual(list[0], 1)
     }
     /// Returns path to the built products directory.
     var productsDirectory: URL {

--- a/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
+++ b/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 final class SwiftyPyStringTests: XCTestCase {
 
-    func test_CompileTime() throws { }
     func testCapitalize() throws {
         let case1 = "hello world!"
         let case2 = "Hello World!"
@@ -39,14 +38,14 @@ final class SwiftyPyStringTests: XCTestCase {
         XCTAssertEqual(b.count("w"), 0)
         XCTAssertEqual(b.count(i), 4)
         XCTAssertEqual(b.count(w), 0)
-        XCTAssertEqual(b.count("i", start:6), 2)
-        XCTAssertEqual(b.count("p", start:6), 2)
-        XCTAssertEqual(b.count("i", start:1, end:3), 1)
-        XCTAssertEqual(b.count("p", start:7, end:9), 1)
-        XCTAssertEqual(b.count(i, start:6), 2)
-        XCTAssertEqual(b.count(p, start:6), 2)
-        XCTAssertEqual(b.count(i, start:1, end:3), 1)
-        XCTAssertEqual(b.count(p, start:7, end:9), 1)
+        XCTAssertEqual(b.count("i", start: 6), 2)
+        XCTAssertEqual(b.count("p", start: 6), 2)
+        XCTAssertEqual(b.count("i", start: 1, end: 3), 1)
+        XCTAssertEqual(b.count("p", start: 7, end: 9), 1)
+        XCTAssertEqual(b.count(i, start: 6), 2)
+        XCTAssertEqual(b.count(p, start: 6), 2)
+        XCTAssertEqual(b.count(i, start: 1, end: 3), 1)
+        XCTAssertEqual(b.count(p, start: 7, end: 9), 1)
     }
     func testEndswith() throws {
         let s1: String = "hello"
@@ -210,11 +209,11 @@ final class SwiftyPyStringTests: XCTestCase {
         XCTAssertEqual(b.rfind("mississippian"), -1)
         XCTAssertEqual(b.rfind(i), 10)
         XCTAssertEqual(b.rfind(w), -1)
-        XCTAssertEqual(b.rfind("ss", start:3), 5)
-        XCTAssertEqual(b.rfind("ss", start:0, end:6), 2)
-        XCTAssertEqual(b.rfind(i, start:1, end:3), 1)
-        XCTAssertEqual(b.rfind(i, start:3, end:9), 7)
-        XCTAssertEqual(b.rfind(w, start:1, end:3), -1)
+        XCTAssertEqual(b.rfind("ss", start: 3), 5)
+        XCTAssertEqual(b.rfind("ss", start: 0, end: 6), 2)
+        XCTAssertEqual(b.rfind(i, start: 1, end: 3), 1)
+        XCTAssertEqual(b.rfind(i, start: 3, end: 9), 7)
+        XCTAssertEqual(b.rfind(w, start: 1, end: 3), -1)
     }
     func testRjust() throws {
         let str = "abc"
@@ -299,13 +298,13 @@ final class SwiftyPyStringTests: XCTestCase {
 
     /// Returns path to the built products directory.
     var productsDirectory: URL {
-      #if os(macOS)
-        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return bundle.bundleURL.deletingLastPathComponent()
-        }
-        fatalError("couldn't find the products directory")
-      #else
-        return Bundle.main.bundleURL
-      #endif
+        #if os(macOS)
+            for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+                return bundle.bundleURL.deletingLastPathComponent()
+            }
+            fatalError("couldn't find the products directory")
+        #else
+            return Bundle.main.bundleURL
+        #endif
     }
 }

--- a/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
+++ b/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
@@ -189,11 +189,6 @@ final class SwiftyPyStringTests: XCTestCase {
         XCTAssertEqual("abc".replace("bc", new: "bcd"), "abcd")
         XCTAssertEqual("Python python python python".replace("python", new: "Swift", count: 2), "Python Swift Swift python")
     }
-    func testReplaceEmpty() throws {
-        XCTAssertEqual("".replace("", new: "p"), "p")
-        XCTAssertEqual("".replace("", new: "p", count: 0), "")
-        XCTAssertEqual("".replace("", new: "p", count: 1), "")
-    }
     func testRfind() throws {
         let s = "0123456789"
         XCTAssertEqual(s.rfind("0"), 0)

--- a/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
+++ b/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
@@ -128,7 +128,7 @@ final class SwiftyPyStringTests: XCTestCase {
         XCTAssertTrue("abc".isprintable())
         XCTAssertFalse("\u{060D}".isprintable())
     }
-    func testIsApace() throws {
+    func testIsSpace() throws {
         XCTAssertTrue(" ".isspace())
         XCTAssertFalse("".isspace())
         XCTAssertFalse("Speace".isspace())

--- a/Tests/SwiftyPyStringTests/XCTestManifests.swift
+++ b/Tests/SwiftyPyStringTests/XCTestManifests.swift
@@ -5,6 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(SliceTests.allTests),
         testCase(SwiftyPyStringTests.allTests),
+        testCase(EmptyStringTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

- What behavior was changed?  
  - bugfix `split`,`rsplit`,`partition` and `rpartition` method.
     Crash when empty string is entered in argument
- What code was refactored / updated to support this change?  
- What issues are related to this PR? Or why was this change introduced?  

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [x] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
