### PR TITLE
[fix] behavior of `ljust` and `rjust` is reversed

### DIFF
--- a/Sources/SwiftyPyString/SwiftyPyString.swift
+++ b/Sources/SwiftyPyString/SwiftyPyString.swift
@@ -318,7 +318,7 @@ extension String {
         }
         return String(str.dropLast(self.count))
     }
-    public func ljust(_ width: Int, fillchar: Character = " ") -> String {
+    public func rjust(_ width: Int, fillchar: Character = " ") -> String {
         if self.count >= width {
             return self
         }
@@ -415,7 +415,7 @@ extension String {
         }
         return i
     }
-    public func rjust(_ width: Int, fillchar: Character = " ") -> String {
+    public func ljust(_ width: Int, fillchar: Character = " ") -> String {
         if self.count >= width {
             return self
         }
@@ -673,10 +673,10 @@ extension String {
         if !self.isEmpty {
             let h = self[0, 1]
             if h == "+" || h == "-" {
-                return h + self[1, nil].ljust(width - 1, fillchar: "0")
+                return h + self[1, nil].rjust(width - 1, fillchar: "0")
             }
         }
-        return self.ljust(width, fillchar: "0")
+        return self.rjust(width, fillchar: "0")
     }
 }
 

--- a/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
+++ b/Tests/SwiftyPyStringTests/SwiftyPyStringTests.swift
@@ -174,8 +174,8 @@ final class SwiftyPyStringTests: XCTestCase {
     func testLjust() throws {
         let str = "abc"
         XCTAssertEqual(str.ljust(1), "abc")
-        XCTAssertEqual(str.ljust(5), "  abc")
-        XCTAssertEqual(str.ljust(5, fillchar: "z"), "zzabc")
+        XCTAssertEqual(str.ljust(5), "abc  ")
+        XCTAssertEqual(str.ljust(5, fillchar: "z"), "abczz")
     }
     func testLower() throws {
         XCTAssertEqual("ABCDE".lower(), "abcde")
@@ -229,8 +229,8 @@ final class SwiftyPyStringTests: XCTestCase {
     func testRjust() throws {
         let str = "abc"
         XCTAssertEqual(str.rjust(1), "abc")
-        XCTAssertEqual(str.rjust(5), "abc  ")
-        XCTAssertEqual(str.rjust(5, fillchar: "z"), "abczz")
+        XCTAssertEqual(str.rjust(5), "  abc")
+        XCTAssertEqual(str.rjust(5, fillchar: "z"), "zzabc")
     }
     func testRpartition() throws {
         XCTAssert("a,b,c".rpartition(",") == ("a,b", ",", "c"))


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

- What behavior was changed?  
  - Fixed the problem that the behavior of `ljust` and `rjust` is reversed

Checklist - While not every PR needs it, new features should consider this list:  
- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [x] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
